### PR TITLE
Assign codeowners to tm-sudo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @salemove/tm-sudo


### PR DESCRIPTION
This PR adds CODEOWNERS file and assigns tm-sudo as codeowners.